### PR TITLE
Amazon eu vat summary calc

### DIFF
--- a/Helper Files/amazon_accounting_report.py
+++ b/Helper Files/amazon_accounting_report.py
@@ -12,13 +12,13 @@ import os
 # GLOBAL VARIABLES
 TESTING = False
 AMZN_CHANNEL = 'COM'
-TEST_TODAY_DATE = '2021-04-23'
+TEST_TODAY_DATE = '2021-07-08'
 EXPECTED_SYS_ARGS = 3
 VBA_ERROR_ALERT = 'ERROR_CALL_DADDY'
 VBA_KEYERROR_ALERT = 'ERROR_IN_SOURCE_HEADERS'
 VBA_OK = 'EXPORTED_SUCCESSFULLY'
 if is_windows_machine():
-    # TEST_AMZN_EXPORT_TXT = r'C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\export 2021.02.01.txt'
+    # TEST_AMZN_EXPORT_TXT = r'C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\export 2021.04.29 EU.txt'
     TEST_AMZN_EXPORT_TXT = r'C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\amazonCOM 2021.04.14.txt'
 else:
     TEST_AMZN_EXPORT_TXT = r'/home/devyo/Coding/Git/Amazon Accounting Report/Amazon exports/run1.txt'

--- a/Helper Files/amzn_parser_constants.py
+++ b/Helper Files/amzn_parser_constants.py
@@ -17,16 +17,11 @@ EU_SUMMARY_HEADERS = ['Currency',
                 '  Date ',
                 '  Total',
                 'Total #',
-                'VAT   ',
-                '  #',
                 'NON-VAT',
                 '  #',
                 '',
-                'DE    ',
-                '  #',
-                'DE Taxes',
-                 '',
-                'UK TAXES']
+                'UK TAXES',
+                '',]
 
 
 COM_SUMMARY_HEADERS = ['Currency',

--- a/Helper Files/amzn_parser_utils.py
+++ b/Helper Files/amzn_parser_utils.py
@@ -92,6 +92,27 @@ def col_to_letter(col : int, zero_indexed=True) -> str:
         col += 1
     return get_column_letter(col)
 
+def get_last_used_row_col(ws:object):
+    '''returns dictionary containing max_row and max_col as integers - last used row and column in passed openpyxl worksheet'''
+    row = ws.max_row
+    while row > 0:
+        cells = ws[row]
+        if all([cell.value is None for cell in cells]):
+            row -= 1
+        else:
+            break
+    if row == 0:
+        return {'max_row' : 0, 'max_col' : 0}
+
+    column = ws.max_column
+    while column > 0:
+        cells = next(ws.iter_cols(min_col=column, max_col=column, max_row=row))
+        if all([cell.value is None for cell in cells]):
+            column -= 1
+        else:
+            break
+    return {'max_row' : row, 'max_col' : column}
+
 def export_json_data(dataobj : dict, json_path : str ='export.json'):
     '''exports dataobj in json format'''
     with open(json_path, 'w') as f:

--- a/Helper Files/orders_report.py
+++ b/Helper Files/orders_report.py
@@ -355,16 +355,6 @@ class AmazonCOMOrdersReport(AmazonEUOrdersReport):
     Main method: export() - creates individual sheets, pushes selected data from corresponding orders;
     creates summary sheet, calculates regional / currency based totals'''
 
-    # def __init__(self, export_obj:dict, eu_countries:list):
-    #     super().__init__(export_obj)
-    #     self.eu_countries = eu_countries
-
-    def _get_report_objs(self):
-        '''prepares cls variables for excel report workbook filling'''
-        self.segments_orders_obj = self._get_segments_orders_obj(self.export_obj)
-        self.summary_table_obj = self._get_summary_table_obj(self.export_obj)
-        self.summary_taxes_obj = self._get_summary_taxes_obj()
-
     def _get_summary_taxes_obj(self):
         '''Returns currency and date based calculated taxes for UK orders (item-tax + shipping)
         

--- a/Helper Files/report.log
+++ b/Helper Files/report.log
@@ -1,23 +1,46 @@
 INFO:root:
- NEW RUN STARTING: 2021.04.25 16:57
-INFO:root:Accepted sys args on launch: txt_path: C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\export 2021.02.08.txt, amzn_channel: EU
+ NEW RUN STARTING: 2021.07.08 17:25
+INFO:root:Accepted sys args on launch: txt_path: C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\export 2021.04.29 EU.txt, amzn_channel: EU
 INFO:root:file exists, continuing to processing...
-INFO:root:Filter date used in program: 2021-04-25 00:00:00. Passing to vba and logging strftime format: 2021-04-25
-INFO:root:Orders passed today date filtering: 560/560
-INFO:root:Returning 560/560 new/loaded orders for further processing
-INFO:root:After checking with database, further processing: 560 new orders
+INFO:root:Filter date used in program: 2021-07-08 00:00:00. Passing to vba and logging strftime format: 2021-07-08
+INFO:root:Orders passed today date filtering: 346/346
+INFO:root:Returning 346/346 new/loaded orders for further processing
+INFO:root:After checking with database, further processing: 346 new orders
 INFO:root:Passing orders to create report with AmazonEUOrdersReport class
-INFO:root:XLSX report AmazonEU Report 2021.04.25 16.57.xlsx successfully created.
-INFO:root:New database backup amzn_accounting_b4lrun.db created on: 2021-04-25 16:57 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_b4lrun.db
+INFO:root:XLSX report AmazonEU Report 2021.07.08 17.25.xlsx successfully created.
+INFO:root:New database backup amzn_accounting_b4lrun.db created on: 2021-07-08 17:25 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_b4lrun.db
 INFO:root:Created backup amzn_accounting_b4lrun.db before adding orders
 INFO:root:Current program_runs id: 1
-INFO:root:560 new orders were successfully added to database at run: 1
+INFO:root:346 new orders were successfully added to database at run: 1
 INFO:root:Deleted old orders (cascade) from orders table where run_id = []
-INFO:root:New database backup amzn_accounting_lrun.db created on: 2021-04-25 16:57 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_lrun.db
+INFO:root:New database backup amzn_accounting_lrun.db created on: 2021-07-08 17:25 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_lrun.db
 INFO:root:Created backup amzn_accounting_lrun.db after adding orders
-INFO:root:Connection to DB in session with file export 2021.02.08.txt closed
-INFO:root:Total of 560 new orders have been added to database, after exports were completed
-INFO:root:Connection to DB in session with file export 2021.02.08.txt closed
+INFO:root:Connection to DB in session with file export 2021.04.29 EU.txt closed
+INFO:root:Total of 346 new orders have been added to database, after exports were completed
+INFO:root:Connection to DB in session with file export 2021.04.29 EU.txt closed
 INFO:root:
-RUN ENDED: 2021.04.25 16:57
+RUN ENDED: 2021.07.08 17:25
+
+INFO:root:
+ NEW RUN STARTING: 2021.07.08 17:25
+INFO:root:Accepted sys args on launch: txt_path: C:\Coding\Ebay\Working\Backups\Amazon exports\Collected exports\export COM 2021.06.28 - MXN new curency.txt, amzn_channel: COM
+INFO:root:file exists, continuing to processing...
+INFO:root:Filter date used in program: 2021-07-08 00:00:00. Passing to vba and logging strftime format: 2021-07-08
+INFO:root:Orders passed today date filtering: 81/81
+INFO:root:Returning 81/81 new/loaded orders for further processing
+INFO:root:After checking with database, further processing: 81 new orders
+INFO:root:Passing orders to create report with AmazonCOMOrdersReport class
+INFO:root:XLSX report AmazonCOM Report 2021.07.08 17.25.xlsx successfully created.
+INFO:root:New database backup amzn_accounting_b4lrun.db created on: 2021-07-08 17:25 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_b4lrun.db
+INFO:root:Created backup amzn_accounting_b4lrun.db before adding orders
+INFO:root:Current program_runs id: 2
+INFO:root:81 new orders were successfully added to database at run: 2
+INFO:root:Deleted old orders (cascade) from orders table where run_id = []
+INFO:root:New database backup amzn_accounting_lrun.db created on: 2021-07-08 17:25 location: C:\Coding\Ebay\Country based sorting\Amazon Accounting Report\Helper Files\amzn_accounting_lrun.db
+INFO:root:Created backup amzn_accounting_lrun.db after adding orders
+INFO:root:Connection to DB in session with file export COM 2021.06.28 - MXN new curency.txt closed
+INFO:root:Total of 81 new orders have been added to database, after exports were completed
+INFO:root:Connection to DB in session with file export COM 2021.06.28 - MXN new curency.txt closed
+INFO:root:
+RUN ENDED: 2021.07.08 17:25
 


### PR DESCRIPTION
Discontinued de_orders separation.

Changes in:
-EU_SUMMARY_HEADERS
-new util func to return max row, max_col in worksheet
-major changes in EU report class, some adjustments to COM report class too.
-recompiled binary

Now all european union member countries have same calculation as separate DE used to have.
-Total: `order['item-price'] + order['shipping-price']`,
-orders count `len(orders_list)'
-and VAT                 `taxes += order['item-tax'] ; taxes += order['shipping-tax']`

Preview:
![image](https://user-images.githubusercontent.com/45366313/124946684-e4a7bd80-e017-11eb-8acc-aabb99b0f2c3.png)
